### PR TITLE
enable aarch64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "skip-arches": ["aarch64", "i386"]
+    "skip-arches": ["i386"]
 }


### PR DESCRIPTION
There have been fixes in gfortran, so let's look at aarch64 support again.

https://github.com/flathub/org.freedesktop.Sdk.Extension.gfortran-62/pull/2